### PR TITLE
feat: Responsive UI, 404 pages, and move Flickr API key to server-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ node_modules
 
 
 # local env files
+.env
 .env.local
 .env.*.local
+.dev.vars
 
 # Log files
 npm-debug.log*

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "typing-app",
       "dependencies": {
-        "axios": "^1.7.0",
         "canvas-confetti": "^1.9.3",
         "hono": "^4.6.0",
         "react": "^19.0.0",
@@ -366,11 +365,7 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
-
-    "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -394,8 +389,6 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
@@ -417,8 +410,6 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
-
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -442,8 +433,6 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
-
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -452,11 +441,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
-
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
-
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -574,10 +559,6 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "miniflare": ["miniflare@4.20260508.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260508.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg=="],
@@ -613,8 +594,6 @@
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
-
-    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "axios": "^1.7.0",
     "canvas-confetti": "^1.9.3",
     "hono": "^4.6.0",
     "react": "^19.0.0",

--- a/app/src/components/Images.tsx
+++ b/app/src/components/Images.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import axios from 'axios'
 
 interface LessonWord {
   word: string
@@ -28,21 +27,10 @@ export default function Images({ word, imageData }: { word: string; imageData: L
   }, [])
 
   const getImage = async (text: string) => {
-    const params = new URLSearchParams({
-      method: 'flickr.photos.search',
-      api_key: '2da67eccedeb0b110a63374c5c53cc41',
-      per_page: '4',
-      extras: 'url_s',
-      sort: 'relevance',
-      media: 'photos',
-      safe_search: '1',
-      format: 'json',
-      nojsoncallback: '1',
-      text,
-    })
     try {
-      const response = await axios.get(`https://api.flickr.com/services/rest/?${params}`)
-      const fetched: FlickrPhoto[] = response.data.photos.photo
+      const response = await fetch(`/api/images?text=${encodeURIComponent(text)}`)
+      if (!response.ok) return
+      const fetched: FlickrPhoto[] = await response.json()
       fetched.forEach((photo) => {
         if (photo.url_s) {
           const img = new Image()

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -3,12 +3,35 @@ import { Hono } from 'hono'
 
 type Env = {
   ASSETS: Fetcher
+  FLICKR_API_KEY: string
 }
 
 const app = new Hono<{ Bindings: Env }>()
 
-// Future API routes can be added here
-// app.get('/api/...', ...)
+// Flickr image search proxy (keeps API key server-side)
+app.get('/api/images', async (c) => {
+  const text = c.req.query('text')
+  if (!text) {
+    return c.json({ error: 'text parameter is required' }, 400)
+  }
+
+  const params = new URLSearchParams({
+    method: 'flickr.photos.search',
+    api_key: c.env.FLICKR_API_KEY,
+    per_page: '4',
+    extras: 'url_s',
+    sort: 'relevance',
+    media: 'photos',
+    safe_search: '1',
+    format: 'json',
+    nojsoncallback: '1',
+    text,
+  })
+
+  const response = await fetch(`https://api.flickr.com/services/rest/?${params}`)
+  const data = await response.json<{ photos: { photo: { id: string; url_s: string }[] } }>()
+  return c.json(data.photos.photo)
+})
 
 // Serve static assets, fallback to index.html for SPA routing
 app.get('*', async (c) => {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,7 +1,77 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import fs from 'node:fs'
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
+// Load FLICKR_API_KEY from .dev.vars for local development
+function loadDevVars(): Record<string, string> {
+  try {
+    const content = fs.readFileSync('.dev.vars', 'utf-8')
+    const vars: Record<string, string> = {}
+    for (const line of content.split('\n')) {
+      const [key, ...rest] = line.split('=')
+      if (key && rest.length > 0) {
+        vars[key.trim()] = rest.join('=').trim()
+      }
+    }
+    return vars
+  } catch {
+    return {}
+  }
+}
+
+export default defineConfig(({ command }) => {
+  const devVars = command === 'serve' ? loadDevVars() : {}
+  const flickrApiKey = devVars.FLICKR_API_KEY ?? ''
+
+  return {
+    plugins: [
+      react(),
+      tailwindcss(),
+      // Local dev: mimic the Hono /api/images endpoint
+      ...(command === 'serve'
+        ? [
+            {
+              name: 'flickr-api-proxy',
+              configureServer(server: { middlewares: { use: (fn: (req: { url?: string }, res: { setHeader: (k: string, v: string) => void; end: (body: string) => void; statusCode: number }, next: () => void) => void) => void } }) {
+                server.middlewares.use((req, res, next) => {
+                  if (!req.url?.startsWith('/api/images')) return next()
+                  const url = new URL(req.url, 'http://localhost')
+                  const text = url.searchParams.get('text')
+                  if (!text) {
+                    res.statusCode = 400
+                    res.setHeader('Content-Type', 'application/json')
+                    res.end(JSON.stringify({ error: 'text parameter is required' }))
+                    return
+                  }
+                  const params = new URLSearchParams({
+                    method: 'flickr.photos.search',
+                    api_key: flickrApiKey,
+                    per_page: '4',
+                    extras: 'url_s',
+                    sort: 'relevance',
+                    media: 'photos',
+                    safe_search: '1',
+                    format: 'json',
+                    nojsoncallback: '1',
+                    text,
+                  })
+                  fetch(`https://api.flickr.com/services/rest/?${params}`)
+                    .then((r) => r.json() as Promise<{ photos: { photo: { id: string; url_s: string }[] } }>)
+                    .then((data) => {
+                      res.setHeader('Content-Type', 'application/json')
+                      res.end(JSON.stringify(data.photos.photo))
+                    })
+                    .catch(() => {
+                      res.statusCode = 502
+                      res.setHeader('Content-Type', 'application/json')
+                      res.end(JSON.stringify({ error: 'Failed to fetch from Flickr' }))
+                    })
+                })
+              },
+            },
+          ]
+        : []),
+    ],
+  }
 })

--- a/app/wrangler.toml
+++ b/app/wrangler.toml
@@ -5,3 +5,6 @@ compatibility_date = "2024-01-01"
 [assets]
 directory = "./dist"
 binding = "ASSETS"
+
+# Local development: create app/.dev.vars with FLICKR_API_KEY=your_key
+# Production: wrangler secret put FLICKR_API_KEY


### PR DESCRIPTION
- Make all lesson components responsive (sm/md/lg/xl breakpoints)
- Add 404 page for unknown routes and invalid lesson IDs
- Move Flickr API key from frontend to Hono server-side proxy
- Add /api/images endpoint in worker.ts
- Add Vite dev middleware to proxy Flickr API locally
- Remove axios dependency (replaced with native fetch)
- Add .env and .dev.vars to .gitignore