### PR TITLE
feat: Add SEO/AIO optimization, GTM, and keyboard favicon

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,11 +2,67 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Typing</title>
+    <title>えいごタイピング練習 | 小学生向け英語タイピング学習アプリ</title>
+    <meta name="description" content="小学生向けの英語タイピング練習アプリ。英単語のスペルをタイピングしながら楽しく英語を学べます。レッスン形式で動物・色・食べ物などの英単語を練習しよう！" />
+    <meta name="keywords" content="タイピング練習,英語,小学生,タイピング,英単語,キーボード練習,子供向け,学習アプリ" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="https://typing.twit.jp/" />
+    <meta name="theme-color" content="#3b82f6" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="えいごタイピング練習 | 小学生向け英語タイピング学習アプリ" />
+    <meta property="og:description" content="小学生向けの英語タイピング練習アプリ。英単語のスペルをタイピングしながら楽しく英語を学べます。" />
+    <meta property="og:url" content="https://typing.twit.jp/" />
+    <meta property="og:site_name" content="えいごタイピング練習" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="えいごタイピング練習 | 小学生向け英語タイピング学習アプリ" />
+    <meta name="twitter:description" content="小学生向けの英語タイピング練習アプリ。英単語のスペルをタイピングしながら楽しく英語を学べます。" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KZ3T2LC6');</script>
+    <!-- End Google Tag Manager -->
+
+    <!-- Structured Data (JSON-LD) for SEO / AIO -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "えいごタイピング練習",
+      "description": "小学生向けの英語タイピング練習アプリ。英単語のスペルをタイピングしながら楽しく英語を学べます。レッスン形式で動物・色・食べ物などの英単語を練習できます。",
+      "url": "https://typing.twit.jp/",
+      "applicationCategory": "EducationalApplication",
+      "operatingSystem": "Web",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "JPY"
+      },
+      "audience": {
+        "@type": "EducationalAudience",
+        "educationalRole": "student",
+        "suggestedMinAge": 6,
+        "suggestedMaxAge": 12
+      },
+      "inLanguage": ["ja", "en"],
+      "isAccessibleForFree": true,
+      "browserRequirements": "Requires a modern web browser with JavaScript enabled"
+    }
+    </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KZ3T2LC6"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/app/public/favicon.svg
+++ b/app/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="4" y="24" width="120" height="88" rx="12" ry="12" fill="#334155" stroke="#1e293b" stroke-width="3"/>
+  <rect x="16" y="36" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="42" y="36" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="68" y="36" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="94" y="36" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="16" y="58" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="42" y="58" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="68" y="58" width="20" height="16" rx="3" fill="#60a5fa"/>
+  <rect x="94" y="58" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="16" y="80" width="20" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="42" y="80" width="44" height="16" rx="3" fill="#e2e8f0"/>
+  <rect x="94" y="80" width="20" height="16" rx="3" fill="#e2e8f0"/>
+</svg>

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://typing.twit.jp/sitemap.xml

--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://typing.twit.jp/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://typing.twit.jp/history</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- Add meta description, OGP, Twitter Card, canonical URL
- Add JSON-LD structured data (WebApplication schema) for AIO
- Add Google Tag Manager (GTM-KZ3T2LC6)
- Replace default favicon with keyboard-themed SVG
- Add robots.txt and sitemap.xml
- Update domain to typing.twit.jp